### PR TITLE
Day boundary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
@@ -20,7 +20,6 @@ wrapper {
 
 repositories {
     mavenCentral()
-    jcenter()
     google()
 }
 

--- a/src/main/java/com/aragaer/jtt/JttService.java
+++ b/src/main/java/com/aragaer/jtt/JttService.java
@@ -87,6 +87,7 @@ public class JttService extends Service implements SharedPreferences.OnSharedPre
                 toggle_notify(pref.getBoolean(Settings.PREF_NOTIFY, true));
                 break;
             case Settings.PREF_LOCATION:
+            case Settings.PREF_BOUNDARY:
                 ticker.start();
                 break;
             case Settings.PREF_WIDGET:

--- a/src/main/java/com/aragaer/jtt/Settings.java
+++ b/src/main/java/com/aragaer/jtt/Settings.java
@@ -8,6 +8,7 @@ import android.preference.PreferenceManager;
 
 public class Settings {
     public static final String PREF_LOCATION = "jtt_loc";
+    public static final String PREF_BOUNDARY = "jtt_day_boundary";
     public static final String PREF_LOCALE = "jtt_locale";
     public static final String PREF_HNAME = "jtt_hname";
     public static final String PREF_NOTIFY = "jtt_notify";

--- a/src/main/java/com/aragaer/jtt/SettingsFragment.java
+++ b/src/main/java/com/aragaer/jtt/SettingsFragment.java
@@ -20,7 +20,7 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
     private static final String[] prefcodes = {Settings.PREF_LOCATION, Settings.PREF_NOTIFY,
             Settings.PREF_LOCALE, Settings.PREF_HNAME,
             Settings.PREF_THEME, Settings.PREF_WIDGET,
-            Settings.PREF_EMOJI_WIDGET};
+            Settings.PREF_EMOJI_WIDGET, Settings.PREF_BOUNDARY};
 
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         if (preference instanceof ListPreference) {

--- a/src/main/java/com/aragaer/jtt/astronomy/AndroidDayBoundaryHandler.java
+++ b/src/main/java/com/aragaer/jtt/astronomy/AndroidDayBoundaryHandler.java
@@ -1,0 +1,46 @@
+// -*- Mode: Java; tab-width: 4; indent-tabs-mode: nil; -*-
+// vim: et ts=4 sts=4 sw=4 syntax=java
+package com.aragaer.jtt.astronomy;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import com.aragaer.jtt.Settings;
+
+
+public class AndroidDayBoundaryHandler implements DayBoundaryHandler {
+
+    /* Official sunrise/sunset: sun 50' below the horizon. */
+    private static final double OFFICIAL = 0.8333;
+    /* Civil twilight: sun 6 degrees below the horizon. */
+    private static final double CIVIL = 6;
+    /* Edo-period convention for ake-mutsu/kure-mutsu: sun 7 degrees
+     * 21' 40" below the horizon.  Before the Kansei reform, dawn and
+     * dusk were fixed at 2.5 koku (= 36 min; 1 day = 100 koku) before
+     * sunrise / after sunset; the Kansei calendar (1798-1843) redefined
+     * them as the solar depression matching that offset at the equinox
+     * in Kyoto: sin h = -cos(lat) * sin(9 deg), since 2.5 koku = 9
+     * degrees of rotation, giving h = -7deg21'41".  The NAOJ ephemeris
+     * still defines yoake/higure by this angle.  Source: NAOJ Koyomi
+     * Wiki, "Twilight: yoake to higure",
+     * https://eco.mtk.nao.ac.jp/koyomi/wiki/C7F6CCC02FCCEBCCC0A4C8C6FCCAEB.html */
+    private static final double EDO = 7.3611;
+
+    private static final double[] DEPRESSIONS = {OFFICIAL, CIVIL, EDO};
+
+    private final SharedPreferences _pref;
+
+    /* package private */ AndroidDayBoundaryHandler(Context context) {
+        _pref = PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    public double getDepression() {
+        String boundary = _pref.getString(Settings.PREF_BOUNDARY, "0");
+        try {
+            return DEPRESSIONS[Integer.parseInt(boundary)];
+        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+            return OFFICIAL;
+        }
+    }
+}

--- a/src/main/java/com/aragaer/jtt/astronomy/AstronomyModule.java
+++ b/src/main/java/com/aragaer/jtt/astronomy/AstronomyModule.java
@@ -17,8 +17,13 @@ public class AstronomyModule {
         _context = context;
     }
 
-    @Provides public SolarEventCalculator provideSolarEventCalculator(LocationHandler locationHandler) {
-        return new SscAdapter(locationHandler);
+    @Provides public SolarEventCalculator provideSolarEventCalculator(LocationHandler locationHandler,
+                                                                      DayBoundaryHandler boundaryHandler) {
+        return new SscAdapter(locationHandler, boundaryHandler);
+    }
+
+    @Provides public DayBoundaryHandler provideDayBoundaryHandler() {
+        return new AndroidDayBoundaryHandler(_context);
     }
 
     @Provides public LocationHandler provideLocationHandler() {

--- a/src/main/java/com/aragaer/jtt/astronomy/DayBoundaryHandler.java
+++ b/src/main/java/com/aragaer/jtt/astronomy/DayBoundaryHandler.java
@@ -1,0 +1,10 @@
+// -*- Mode: Java; tab-width: 4; indent-tabs-mode: nil; -*-
+// vim: et ts=4 sts=4 sw=4 syntax=java
+package com.aragaer.jtt.astronomy;
+
+
+public interface DayBoundaryHandler {
+    /* Solar depression angle in degrees below the horizon
+     * marking the day/night boundary. */
+    double getDepression();
+}

--- a/src/main/java/com/aragaer/jtt/astronomy/SscAdapter.java
+++ b/src/main/java/com/aragaer/jtt/astronomy/SscAdapter.java
@@ -6,30 +6,39 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
-import com.luckycatlabs.sunrisesunset.SunriseSunsetCalculator;
+import com.luckycatlabs.sunrisesunset.Zenith;
 import com.luckycatlabs.sunrisesunset.dto.Location;
 
 
 public  class SscAdapter implements SolarEventCalculator {
     private final LocationHandler _locationHandler;
+    private final DayBoundaryHandler _boundaryHandler;
 
-    public SscAdapter(LocationHandler locationHandler) {
+    public SscAdapter(LocationHandler locationHandler, DayBoundaryHandler boundaryHandler) {
         _locationHandler = locationHandler;
+        _boundaryHandler = boundaryHandler;
     }
 
     @Override public Calendar getSunriseFor(Calendar noon) {
-        return getCalculator().getOfficialSunriseCalendarForDate((Calendar) noon.clone());
+        return getCalculator().computeSunriseCalendar(getZenith(), (Calendar) noon.clone());
     }
 
     @Override public Calendar getSunsetFor(Calendar noon) {
-        return getCalculator().getOfficialSunsetCalendarForDate((Calendar) noon.clone());
+        return getCalculator().computeSunsetCalendar(getZenith(), (Calendar) noon.clone());
     }
 
-    private SunriseSunsetCalculator getCalculator() {
+    private Zenith getZenith() {
+        /* Note: SunriseSunsetCalculator.getSunrise(..., degrees) statics are
+         * not used here because they construct Zenith(90 - degrees),
+         * contradicting their own javadoc. */
+        return new Zenith(90 + _boundaryHandler.getDepression());
+    }
+
+    private com.luckycatlabs.sunrisesunset.calculator.SolarEventCalculator getCalculator() {
         float[] location = _locationHandler.getLocation();
         int offsetMillis = (int) TimeUnit.HOURS.toMillis(Math.round(location[1]/15));
-        return new SunriseSunsetCalculator(new Location(location[0], location[1]),
-                                           getTimeZone(offsetMillis));
+        return new com.luckycatlabs.sunrisesunset.calculator.SolarEventCalculator(
+                new Location(location[0], location[1]), getTimeZone(offsetMillis));
     }
 
     private static TimeZone getTimeZone(int offsetMillis) {

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -21,6 +21,14 @@
     <string name="hour_names">刻の名前</string>
     <string name="no_providers">場所の取得に失敗しました。位置情報サービスを有効ください</string>
 
+    <string name="day_boundary">昼夜の境界</string>
+
+    <string-array name="day_boundary_names">
+        <item>日の出・日の入り</item>
+        <item>市民薄明（太陽が地平線下6\u00b0）</item>
+        <item>明け六つ・暮れ六つ（地平線下7\u00b022\u2032）</item>
+    </string-array>
+
     <string-array name="hour_name_option_names">
         <item>デフォルト</item>
         <item>ローマ字</item>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -21,6 +21,14 @@
     <string name="hour_names">Названия часов</string>
     <string name="no_providers">Не удается определить координаты. Пожалуйста, включите сервис определения местоположения.</string>
 
+    <string name="day_boundary">Граница дня</string>
+
+    <string-array name="day_boundary_names">
+        <item>Восход и закат</item>
+        <item>Гражданские сумерки (солнце 6\u00b0 под горизонтом)</item>
+        <item>Конвенция Эдо (7\u00b022\u2032 под горизонтом)</item>
+    </string-array>
+
     <string-array name="hour_name_option_names">
         <item>По умолчанию</item>
         <item>Ромадзи</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -21,6 +21,14 @@
     <string name="hour_names">Hour names</string>
     <string name="no_providers">Unable to determine location.\nPlease enable location service.</string>
 
+    <string name="day_boundary">Day boundary</string>
+
+    <string-array name="day_boundary_names">
+        <item>Sunrise and sunset</item>
+        <item>Civil twilight (sun 6\u00b0 below horizon)</item>
+        <item>Edo convention (sun 7\u00b022\u2032 below horizon)</item>
+    </string-array>
+
     <string-array name="hour_name_option_names">
         <item>Default</item>
         <item>Romaji</item>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -6,6 +6,13 @@
       android:key="jtt_loc"
       android:title="@string/location" />
 
+  <ListPreference
+      android:defaultValue="0"
+      android:entries="@array/day_boundary_names"
+      android:entryValues="@array/array_of_3"
+      android:key="jtt_day_boundary"
+      android:title="@string/day_boundary" />
+
   <PreferenceCategory android:title="@string/language" >
 
         <ListPreference

--- a/src/test/java/com/aragaer/jtt/ServiceComponentTest.java
+++ b/src/test/java/com/aragaer/jtt/ServiceComponentTest.java
@@ -96,8 +96,13 @@ class TestAstronomyModule extends AstronomyModule {
         super(null);
     }
 
-    @Override public SolarEventCalculator provideSolarEventCalculator(LocationHandler locationHandler) {
+    @Override public SolarEventCalculator provideSolarEventCalculator(LocationHandler locationHandler,
+                                                                      DayBoundaryHandler boundaryHandler) {
         return new TestSolarEventCalculator();
+    }
+
+    @Override public DayBoundaryHandler provideDayBoundaryHandler() {
+        return new TestDayBoundaryHandler();
     }
 
     @Override public LocationHandler provideLocationHandler() {

--- a/src/test/java/com/aragaer/jtt/astronomy/SscAdapterTest.java
+++ b/src/test/java/com/aragaer/jtt/astronomy/SscAdapterTest.java
@@ -14,10 +14,12 @@ public class SscAdapterTest {
 
     private SscAdapter _calculator;
     private TestLocationHandler _locationHandler;
+    private TestDayBoundaryHandler _boundaryHandler;
 
     @Before public void setUp() {
         _locationHandler = new TestLocationHandler();
-        _calculator = new SscAdapter(_locationHandler);
+        _boundaryHandler = new TestDayBoundaryHandler();
+        _calculator = new SscAdapter(_locationHandler, _boundaryHandler);
     }
 
     @Test public void testSunriseLondon01Jan2000() {
@@ -89,6 +91,32 @@ public class SscAdapterTest {
         // Note - next day, after midnight
         Calendar sunset = _calculator.getSunsetFor(calendar);
         verifyEquals(sunset, 2017, 5, 23, 0, 4, tz);
+    }
+
+    @Test public void testCivilTwilightWidensTheDay() {
+        _locationHandler.setLocation(51.5f, 0f);
+        int offsetMillis = (int) TimeUnit.MINUTES.toMillis(0);
+        TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs(offsetMillis)[0]);
+        Calendar calendar = Calendar.getInstance(tz);
+        calendar.set(2000, 0, 1, 12, 0, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+        Calendar officialSunrise = _calculator.getSunriseFor(calendar);
+        Calendar officialSunset = _calculator.getSunsetFor(calendar);
+
+        _boundaryHandler.setDepression(6);
+        Calendar civilSunrise = _calculator.getSunriseFor(calendar);
+        Calendar civilSunset = _calculator.getSunsetFor(calendar);
+
+        long dawnShift = officialSunrise.getTimeInMillis() - civilSunrise.getTimeInMillis();
+        long duskShift = civilSunset.getTimeInMillis() - officialSunset.getTimeInMillis();
+
+        // Civil dawn precedes official sunrise (and dusk follows sunset)
+        // by roughly half an hour at London's latitude in January.
+        assertTrue("civil dawn should precede sunrise", dawnShift > TimeUnit.MINUTES.toMillis(20));
+        assertTrue("civil dawn shift should be sane", dawnShift < TimeUnit.MINUTES.toMillis(60));
+        assertTrue("civil dusk should follow sunset", duskShift > TimeUnit.MINUTES.toMillis(20));
+        assertTrue("civil dusk shift should be sane", duskShift < TimeUnit.MINUTES.toMillis(60));
     }
 
     private static void verifyEquals(Calendar actual, int year, int month,

--- a/src/test/java/com/aragaer/jtt/astronomy/TestDayBoundaryHandler.java
+++ b/src/test/java/com/aragaer/jtt/astronomy/TestDayBoundaryHandler.java
@@ -1,0 +1,17 @@
+// -*- Mode: Java; tab-width: 4; indent-tabs-mode: nil; -*-
+// vim: et ts=4 sts=4 sw=4 syntax=java
+package com.aragaer.jtt.astronomy;
+
+
+public class TestDayBoundaryHandler implements DayBoundaryHandler {
+
+    private double _depression = 0.8333;
+
+    public void setDepression(double depression) {
+        _depression = depression;
+    }
+
+    @Override public double getDepression() {
+        return _depression;
+    }
+}


### PR DESCRIPTION
Historically the Edo-period ake-mutsu/kure-mutsu were defined by twilight
(sun ~7°21' below the horizon), not by the solar disk crossing the horizon.
This PR adds a "Day boundary" preference with three options: official
sunrise/sunset (default, existing behaviour), civil twilight (6°), and the
Edo convention (7°22').

Implementation follows the existing LocationHandler pattern
(DayBoundaryHandler + Android impl, wired via Dagger). SscAdapter now
computes through SolarEventCalculator.computeSunriseCalendar(new Zenith(90 +
depression)) — the library's static getSunrise(..., degrees) helpers were
deliberately avoided: they construct Zenith(90 − degrees), contradicting
their own javadoc. Behaviour is bit-identical for the default option
(existing unit tests unchanged and passing); a new test covers the twilight
path. Strings added for en/ru/ja.

Two preparatory commits fix the build, which is currently broken on master:
jcenter is defunct (replaced with mavenCentral), and the values-zh-hant
resource directory has an invalid name for aapt2 (renamed to
values-b+zh+Hant per BCP 47).

Note: JttServiceTest.testStart fails on current master independently of
this PR — the `notify = true` hotfix in toggle_notify() forces JttStatus
construction, which hits unmocked getSystemService in JVM unit tests. It
appears the last commits landed after Travis CI shut down in 2021 and were
never CI-tested. All astronomy tests pass.